### PR TITLE
Add .idea/ and .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ coverage.xml
 *.log
 docker-compose.override.yml
 docker-compose.override.yaml
+
+# IntelliJ IDEA
+.idea/
+
+# macOS system files
+.DS_Store


### PR DESCRIPTION
Update the .gitignore file to exclude IntelliJ IDEA project files and macOS system files. This helps to avoid committing user-specific configuration and unnecessary system files to the repository.